### PR TITLE
Add homeassistant mqtt discovery

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,9 @@ First set mode, then go further down in this file to set other options needed fo
 // #define useTemperatureSensorBME280
 #define useWIFI
 #define useMQTT
+#ifdef useMQTT
+  // #define useHomeassistant
+#endif
 // #define useTFT
   #ifdef useTFT
     // --- choose which display to use. Activate only one. -----------------------------------------------
@@ -145,6 +148,10 @@ const char* const mqttCmndFanPWM         = "esp32_fan_controller/cmnd/FANPWM";
 const char* const mqttStatFanPWM         = "esp32_fan_controller/stat/FANPWM";
 #if defined(useOTAUpdate)
 const char* const mqttCmndOTA            = "esp32_fan_controller/cmnd/OTA";
+#endif
+#if defined(useHomeassistant)
+const char* const hassDiscoveryPayload   = "{\"name\":\"esp32_fan_controller\",\"~\": \"esp32_fan_controller\",\"uniq_id\":\"esp32_fan_controller\",\"modes\":[\"fan_only\"],\"current_humidity_topic\":\"~/tele/STATE1\",\"current_humidity_template\":\"{{value_json.hum}}\",\"curr_temp_t\":\"~/stat/ACTUALTEMP\",\"temp_stat_t\":\"~/stat/TARGETTEMP\",\"temp_cmd_t\":\"~/cmnd/TARGETTEMP\",\"temp_unit\":\"C\",\"precision\":1.0,\"temp_step\":1,\"min_temp\":10,\"max_temp\":50,\"o\":{\"name\":\"esp32-fan-controller\",\"support_url\":\"https://github.com/KlausMu/esp32-fan-controller\"}}";
+const char* const hassDiscoveryTopic     = "homeassistant/climate/esp32_fan_controller/config";
 #endif
 
 #ifdef useTemperatureSensorBME280

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,9 @@ unsigned long previousMillis1000Cycle = 0;
 unsigned long interval1000Cycle = 1000;
 unsigned long previousMillis10000Cycle = 0;
 unsigned long interval10000Cycle = 10000;
+#ifdef useHomeassistant
+bool hasPublishedDiscovery = false;
+#endif
 
 void setup(){
   Serial.begin(115200);
@@ -58,6 +61,9 @@ void setup(){
   #ifdef useAutomaticTemperatureControl
   initTemperatureController();
   #endif
+  #ifdef useMQTT
+  mqtt_setup();
+  #endif
 
   Log.printf("Settings done. Have fun.\r\n");
 }
@@ -89,6 +95,11 @@ void loop(){
     #endif
     #ifdef useAutomaticTemperatureControl
     setFanPWMbasedOnTemperature();
+    #endif
+    #ifdef useHomeassistant
+      if (!hasPublishedDiscovery) {
+        hasPublishedDiscovery = mqtt_publish_hass_discovery();
+      }
     #endif
     #ifdef useTFT
     draw_screen();

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -36,6 +36,13 @@ PubSubClient mqttClient(mqtt_server, mqtt_server_port, callback, wifiClient);
 
 bool checkMQTTconnection();
 
+void mqtt_setup() {
+  #ifdef useHomeassistant
+  // Set buffer size to allow hass discovery payload
+  mqttClient.setBufferSize(640);
+  #endif
+}
+
 void mqtt_loop(){
   if (!mqttClient.connected()) {
     unsigned long currentMillis = millis();
@@ -109,6 +116,13 @@ bool mqtt_publish_stat_actualTemp() {
 bool mqtt_publish_stat_fanPWM() {
   return publishMQTTMessage(mqttStatFanPWM,     ((String)getPWMvalue()).c_str());
 };
+bool mqtt_publish_hass_discovery() {
+  #if defined(useHomeassistant)
+  return publishMQTTMessage(hassDiscoveryTopic, hassDiscoveryPayload);
+  #else
+  return false;
+  #endif
+}
 
 bool mqtt_publish_tele() {
   bool error = false;

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -1,7 +1,9 @@
 #ifdef useMQTT
+void mqtt_setup(void);
 void mqtt_loop(void);
 bool mqtt_publish_tele(void);
 bool mqtt_publish_stat_targetTemp();
 bool mqtt_publish_stat_actualTemp();
 bool mqtt_publish_stat_fanPWM();
+bool mqtt_publish_hass_discovery();
 #endif


### PR DESCRIPTION
Discovery automatically configures the controller as a HVAC fan only device in homeassistant.

Enable by uncommenting ```#define useHomeassistant``` in config.h

![image](https://github.com/KlausMu/esp32-fan-controller/assets/66720563/2783d61f-48e2-420d-bf38-46806dbe7a4d)

![image](https://github.com/KlausMu/esp32-fan-controller/assets/66720563/9c450200-568e-460d-8674-b1158688d90d)
