### PR TITLE
Add homeassistent mqtt discovery

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,9 @@ First set mode, then go further down in this file to set other options needed fo
 // #define useTemperatureSensorBME280
 #define useWIFI
 #define useMQTT
+#ifdef useMQTT
+#define useHomeassistant
+#endif			    
 // #define useTFT
   #ifdef useTFT
     // --- choose which display to use. Activate only one. -----------------------------------------------
@@ -127,6 +130,7 @@ const int mqtt_server_port               = 1883;
 const char* const mqtt_user              = "myUser or empty";
 const char* const mqtt_pass              = "myPassword or empty";
 const char* const mqtt_clientName        = "esp32_3dprinter";
+
 /*
 For understanding when "cmnd", "stat" and "tele" is used, have a look at how Tasmota is doing it.
 https://tasmota.github.io/docs/MQTT
@@ -146,7 +150,24 @@ const char* const mqttStatFanPWM         = "esp32_fan_controller/stat/FANPWM";
 #if defined(useOTAUpdate)
 const char* const mqttCmndOTA            = "esp32_fan_controller/cmnd/OTA";
 #endif
-
+#if defined(useHomeassistant)
+const char* const hassDiscoveryPayload   = "{\"name\":\"Fan_Controller\",\"unique_id\":\"Fan_Controller\",\"icon\":\"mdi:fan\",\"min_temp\":10,\"max_temp\":50,\"temp_step\":1.0,\"current_humidity_topic\":\"esp32_fan_controller/tele/STATE1\",\"current_humidity_template\":\"{{value_json.hum}}\",\"current_temperature_topic\":\"esp32_fan_controller/stat/ACTUALTEMP\", \"temperature_command_topic\":\"esp32_fan_controller/cmnd/TARGETTEMP\",\"temperature_state_topic\":\"esp32_fan_controller/stat/TARGETTEMP\",\"modes\":[\"fan_only\"], \"mode_command_topic\":\"esp32_fan_controller/tele/STATE2\",\"mode_command_template\":\"{{ value_json.mode }}\",\"mode_state_topic\":\"homeassistant/climate/esp32_fan_controller/state\",\"mode_state_template\":\"{{ value_json.mode }}\",\"precision\":1.0,\"device\":{\"identifiers\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"model\":\"esp32_fan_controller\",\"manufacturer\":\"KlausMu\"}}";
+const char* const hassDiscoveryTopic     = "homeassistant/climate/esp32_fan_controller/config";
+const char* const hassStatus             = "homeassistant/status";
+const char* const hassFanStateTopic      = "homeassistant/climate/esp32_fan_controller/state";
+const char* const hassFanstatePayload    = "fan_only";
+const char* const hassDSensor1Topic      = "homeassistant/sensor/esp32_fan_controller/humidity/config";
+const char* const hassDSensor2Topic      = "homeassistant/sensor/esp32_fan_controller/temperature/config";
+const char* const hassDSensor3Topic      = "homeassistant/sensor/esp32_fan_controller/pressure/config";
+const char* const hassDSensor4Topic      = "homeassistant/sensor/esp32_fan_controller/altitude/config";
+const char* const hassDSensor5Topic      = "homeassistant/sensor/esp32_fan_controller/rpm/config";
+const char* const hassDSensor1Payload    = "{\"unit_of_measurement\":\"%\",\"dev_cla\":\"humidity\",\"value_template\":\"{{ value_json.hum }}\",\"state_class\":\"measurement\",\"stat_t\":\"esp32_fan_controller/tele/STATE1\",\"name\":\"Humidity\",\"uniq_id\":\"esp32_humidity\",\"dev\":{\"ids\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"mdl\":\"esp32_fan_controller\",\"mf\":\"KlausMu\"}}";
+const char* const hassDSensor2Payload    = "{\"unit_of_measurement\":\"C\",\"dev_cla\":\"temperature\",\"value_template\":\"{{ value_json.ActTemp }}\",\"state_class\":\"measurement\",\"stat_t\":\"esp32_fan_controller/tele/STATE1\",\"name\":\"Temperature\",\"uniq_id\":\"esp32_temperature\",\"dev\":{\"ids\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"mdl\":\"esp32_fan_controller\",\"mf\":\"KlausMu\"}}";
+const char* const hassDSensor3Payload    = "{\"unit_of_measurement\":\"hPa\",\"dev_cla\":\"atmospheric_pressure\",\"value_template\":\"{{ value_json.pres }}\",\"state_class\":\"measurement\",\"stat_t\":\"esp32_fan_controller/tele/STATE1\",\"name\":\"Pressure\",\"uniq_id\":\"esp32_pressure\",\"dev\":{\"ids\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"mdl\":\"esp32_fan_controller\",\"mf\":\"KlausMu\"}}";
+const char* const hassDSensor4Payload    = "{\"unit_of_measurement\":\"M\",\"dev_cla\":\"distance\",\"value_template\":\"{{ value_json.alt }}\",\"state_class\":\"measurement\",\"stat_t\":\"esp32_fan_controller/tele/STATE1\",\"name\":\"Altitude\",\"uniq_id\":\"esp32_altitude\",\"dev\":{\"ids\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"mdl\":\"esp32_fan_controller\",\"mf\":\"KlausMu\"}}";
+const char* const hassDSensor5Payload    = "{\"unit_of_measurement\":\"RPM\",\"dev_cla\":\"frequency\",\"value_template\":\"{{ value_json.rpm }}\",\"state_class\":\"measurement\",\"stat_t\":\"esp32_fan_controller/tele/STATE2\",\"name\":\"RPM\",\"uniq_id\":\"esp32_RPM\",\"dev\":{\"ids\":[\"esp32_fan_controller\"],\"name\":\"esp32_fan_controller\",\"mdl\":\"esp32_fan_controller\",\"mf\":\"KlausMu\"}}";
+#endif							 
+	
 #ifdef useTemperatureSensorBME280
 const char* const mqttTeleState1         = "esp32_fan_controller/tele/STATE1";
 #endif
@@ -201,7 +222,7 @@ const int TOUCH_CS              = GPIO_NUM_14;
 // https://www.az-delivery.de/en/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/az-touch-mod
 const int TOUCH_IRQ            = GPIO_NUM_27 ;   // touch screen interrupt
 #endif
-const int LED_ON               = HIGH;
+const int LED_ON               = LOW;
 
 // sanity check
 #if defined(useTouch) && !defined(useTFT)

--- a/src/config.h
+++ b/src/config.h
@@ -30,8 +30,8 @@ First set mode, then go further down in this file to set other options needed fo
 #define useWIFI
 #define useMQTT
 #ifdef useMQTT
-#define useHomeassistant
-#endif			    
+  // #define useHomeassistant
+#endif
 // #define useTFT
   #ifdef useTFT
     // --- choose which display to use. Activate only one. -----------------------------------------------
@@ -222,7 +222,7 @@ const int TOUCH_CS              = GPIO_NUM_14;
 // https://www.az-delivery.de/en/blogs/azdelivery-blog-fur-arduino-und-raspberry-pi/az-touch-mod
 const int TOUCH_IRQ            = GPIO_NUM_27 ;   // touch screen interrupt
 #endif
-const int LED_ON               = LOW;
+const int LED_ON               = HIGH;
 
 // sanity check
 #if defined(useTouch) && !defined(useTFT)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,9 @@ unsigned long previousMillis1000Cycle = 0;
 unsigned long interval1000Cycle = 1000;
 unsigned long previousMillis10000Cycle = 0;
 unsigned long interval10000Cycle = 10000;
+#ifdef useHomeassistant
+bool hasPublishedDiscovery = false;
+#endif
 
 void setup(){
   Serial.begin(115200);
@@ -58,6 +61,9 @@ void setup(){
   #ifdef useAutomaticTemperatureControl
   initTemperatureController();
   #endif
+  #ifdef useMQTT
+  mqtt_setup();
+  #endif
 
   Log.printf("Settings done. Have fun.\r\n");
 }
@@ -89,6 +95,11 @@ void loop(){
     #endif
     #ifdef useAutomaticTemperatureControl
     setFanPWMbasedOnTemperature();
+    #endif
+    #ifdef useHomeassistant
+      if (!hasPublishedDiscovery) {
+        hasPublishedDiscovery = mqtt_publish_hass_discovery();
+      }
     #endif
     #ifdef useTFT
     draw_screen();

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -36,6 +36,13 @@ PubSubClient mqttClient(mqtt_server, mqtt_server_port, callback, wifiClient);
 
 bool checkMQTTconnection();
 
+void mqtt_setup() {
+  #ifdef useHomeassistant
+  // Set buffer size to allow hass discovery payload
+  mqttClient.setBufferSize(1280);
+  #endif
+}
+
 void mqtt_loop(){
   if (!mqttClient.connected()) {
     unsigned long currentMillis = millis();
@@ -69,6 +76,9 @@ bool checkMQTTconnection() {
         mqttClient.subscribe(mqttCmndFanPWM);
         #if defined(useOTAUpdate)
         mqttClient.subscribe(mqttCmndOTA);
+        #endif
+        #if defined(useHomeassistant)
+        mqttClient.subscribe(hassStatus);
         #endif
       } else {
         Log.printf("  MQTT connection failed (but WiFi is available). Will try later ...\r\n");
@@ -109,6 +119,13 @@ bool mqtt_publish_stat_actualTemp() {
 bool mqtt_publish_stat_fanPWM() {
   return publishMQTTMessage(mqttStatFanPWM,     ((String)getPWMvalue()).c_str());
 };
+bool mqtt_publish_hass_discovery() {
+  #if defined(useHomeassistant)
+  return publishMQTTMessage(hassDiscoveryTopic, hassDiscoveryPayload);
+  #else
+  return false;
+  #endif
+}
 
 bool mqtt_publish_tele() {
   bool error = false;
@@ -186,6 +203,9 @@ void callback(char* topic, byte* payload, unsigned int length) {
   #if defined(useOTAUpdate)
   String topicCmndOTA(mqttCmndOTA);
   #endif
+  #if defined(useHomeassistant)
+  String topicHaStatus(hassStatus);
+  #endif
   if (topicReceived == topicCmndTargetTemp) {
     #ifdef useAutomaticTemperatureControl
     Log.printf("Setting targetTemp via mqtt\r\n");
@@ -224,6 +244,22 @@ void callback(char* topic, byte* payload, unsigned int length) {
     } else if (strPayload == "OFF") {
       Log.printf("MQTT command TURN OFF OTA received\r\n");
       ArduinoOTA.end();
+    } else {
+      Log.printf("Payload %s not supported\r\n", strPayload.c_str());
+    }
+#endif
+#if defined(useHomeassistant)
+  } else if (topicReceived == hassStatus) {
+    if (strPayload == "online") {
+      Log.printf("MQTT command Rediscovery received\r\n");
+      publishMQTTMessage(hassDiscoveryTopic, hassDiscoveryPayload);
+      publishMQTTMessage(hassFanStateTopic, hassFanstatePayload);
+      publishMQTTMessage(hassDSensor1Topic, hassDSensor1Payload);
+      publishMQTTMessage(hassDSensor2Topic, hassDSensor2Payload);
+      publishMQTTMessage(hassDSensor3Topic, hassDSensor3Payload);
+      publishMQTTMessage(hassDSensor4Topic, hassDSensor4Payload);
+      publishMQTTMessage(hassDSensor5Topic, hassDSensor5Payload);
+      publishMQTTMessage(mqttStatTargetTemp, ((String)getTargetTemperature()).c_str());
     } else {
       Log.printf("Payload %s not supported\r\n", strPayload.c_str());
     }

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -1,7 +1,9 @@
 #ifdef useMQTT
+void mqtt_setup(void);
 void mqtt_loop(void);
 bool mqtt_publish_tele(void);
 bool mqtt_publish_stat_targetTemp();
 bool mqtt_publish_stat_actualTemp();
 bool mqtt_publish_stat_fanPWM();
+bool mqtt_publish_hass_discovery();
 #endif


### PR DESCRIPTION
Hi KlausMu, 

I managed to take the changes from #15 and modify the home assistent discovery payloads. I am getting the hang of stuff, but i am not a programmer.  I managed to succeed in subscribing to topic [homeassistent/status] and act accordingly when receiving a online message, to facilitate for HA restarts.  The fan state also has to be in a topic, this is also created. 

For testing, you can use mqtt explorer to send online message to topic [homeassistent/status].

At this points mqtt discovery of the fan and sensors is only fully done on HA restart/online message. 
This needs a good look by some1 who has programming knowledge in c. 

The newly created discovery payloads need to be done at the start of the device, but i could not wrap my head around this,  with my knowledge :).  

For now there is just a few things left to do, to make this great. Since the groundwork has been done. I assume this could be easy for you to do. 

1. All discovery payloads on esp32 start. 
2. Make pubsubclient set a retained last will message on connect to topic [homeassistant/climate/esp32_fan_controller/status]  payload >>[offline] (seems to be quite easy to do, but my programming skills/time are insufficient). 
3. Enable retained messages.   modify "mqtt.cpp" line nr. 97 to mqttClient.publish(topic, payload, true).

If these changes can be made, i can modify the discovery string of the fan to include availability on the last will topic. After this, the discovery on restart part can be removed and retained messages enabled. We make the fan unavailable when pulling the power and available when online. No ghost entities and proper handling of online/offline status of the device. 
![mqttdiscoveryfan](https://github.com/KlausMu/esp32-fan-controller/assets/62392791/788097bd-ea7d-40cf-b705-a84ed871fbe1)







