### PR TITLE
fix: correct sucessfully→successfully typo in TFT log

### DIFF
--- a/src/tft.cpp
+++ b/src/tft.cpp
@@ -64,7 +64,7 @@ void initTFT(void) {
   draw_screen();
 
   // show the displays resolution
-  Log.printf("  TFT sucessfully initialized.\r\n");
+  Log.printf("  TFT successfully initialized.\r\n");
   Log.printf("  tftx = %d, tfty = %d\r\n", tft.width(), tft.height());
 
   #else


### PR DESCRIPTION
Corrects sucessfully→successfully typo in src/tft.cpp line 67.